### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL-presence-exchange
+++ b/LICENSE-MPL-presence-exchange
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ that are bound to it when other bindings appear and disappear.
 
 From time to time, I make a snapshot binary download of the plugin
 available: see
-<http://eighty-twenty.org/tech/rabbitmq/binary-plugins.html>. Expect
+<https://eighty-twenty.org/tech/rabbitmq/binary-plugins.html>. Expect
 plugins to have a GPG signature from `tonygarnockjones@gmail.com`, key
 available
 [here](http://homepages.kcbbs.gen.nz/tonyg/gpg-key-gmail.txt),
@@ -97,4 +97,4 @@ included with the source code for the package. If you have any
 questions regarding licensing, please contact
 <tonygarnockjones@gmail.com>.
 
-[MPL 2.0]: http://www.mozilla.org/MPL/2.0/
+[MPL 2.0]: https://www.mozilla.org/MPL/2.0/

--- a/src/presence_exchange.erl
+++ b/src/presence_exchange.erl
@@ -1,6 +1,6 @@
 %%  This Source Code Form is subject to the terms of the Mozilla Public
 %%  License, v. 2.0. If a copy of the MPL was not distributed with this
-%%  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
 -module(presence_exchange).
 -include_lib("rabbit_common/include/rabbit.hrl").

--- a/src/presence_exchange_app.erl
+++ b/src/presence_exchange_app.erl
@@ -1,6 +1,6 @@
 %%  This Source Code Form is subject to the terms of the Mozilla Public
 %%  License, v. 2.0. If a copy of the MPL was not distributed with this
-%%  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%%  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
 -module(presence_exchange_app).
 

--- a/test/tests/src/lfp/rabbitmq/presence/tests/PresenceTests.java
+++ b/test/tests/src/lfp/rabbitmq/presence/tests/PresenceTests.java
@@ -1,6 +1,6 @@
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
-//  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 package lfp.rabbitmq.presence.tests;
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html) result SSLHandshakeException).
* http://homepages.kcbbs.gen.nz/tonyg/gpg-key-gmail.txt (200) with 1 occurrences could not be migrated:  
   ([https](https://homepages.kcbbs.gen.nz/tonyg/gpg-key-gmail.txt) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://eighty-twenty.org/tech/rabbitmq/binary-plugins.html (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://eighty-twenty.org/tech/rabbitmq/binary-plugins.html ([https](https://eighty-twenty.org/tech/rabbitmq/binary-plugins.html) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/2.0/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/2.0/ ([https](https://www.mozilla.org/MPL/2.0/) result 301).
* http://mozilla.org/MPL/2.0/ with 4 occurrences migrated to:  
  https://mozilla.org/MPL/2.0/ ([https](https://mozilla.org/MPL/2.0/) result 302).